### PR TITLE
Remove SSL bypass.

### DIFF
--- a/src/keypay-dotnet/Common/ApiRequestExecutor.cs
+++ b/src/keypay-dotnet/Common/ApiRequestExecutor.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Net;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using KeyPayV2.Common.Exceptions;
 using Newtonsoft.Json;
 using RestSharp;
@@ -18,11 +16,6 @@ namespace KeyPayV2.Common
         private readonly string userAgent;
 
         public Action<IRestResponse> ResponseCallback { get; set; }
-
-        static ApiRequestExecutor()
-        {
-            SetSSL();
-        }
 
         public ApiRequestExecutor(string baseUrl, string userAgent = null)
         {
@@ -83,27 +76,5 @@ namespace KeyPayV2.Common
             if (resp.StatusCode >= HttpStatusCode.BadRequest && resp.StatusCode <= HttpStatusCode.InternalServerError)
                 throw new KeyPayHttpException(resp.StatusCode, resp.StatusDescription, requestMethod, requestResource, resp.Content);
         }
-
-        //Trust all certificates
-        // callback used to validate the certificate in an SSL conversation
-        private static bool ValidateRemoteCertificate(object sender, X509Certificate cert, X509Chain chain,
-            SslPolicyErrors policyErrors)
-        {
-            return true;
-        }
-
-        private static void SetSSL()
-        {
-            ServicePointManager.ServerCertificateValidationCallback =
-                ((sender, certificate, chain, sslPolicyErrors) => true);
-
-            // trust sender
-            ServicePointManager.ServerCertificateValidationCallback
-                = ((sender, cert, chain, errors) => true);
-
-            // validate cert by calling a function
-            ServicePointManager.ServerCertificateValidationCallback += ValidateRemoteCertificate;
-        }
-
     }
 }


### PR DESCRIPTION
It seems the code to accept all certificates is an unnecessary security risk. These kinds of calls are sometimes needed, for example in development environments, but can be made from client code and do not need to be included in the SDK.